### PR TITLE
Move tutorials from image_common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(image_transport_tutorial)
+project(image_transport_tutorials)
 
 # Default to C++17
 if(NOT CMAKE_CXX_STANDARD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,90 @@
+cmake_minimum_required(VERSION 3.8)
+project(image_transport_tutorial)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(cv_bridge REQUIRED)
+find_package(image_transport REQUIRED)
+find_package(OpenCV REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(sensor_msgs REQUIRED)
+
+include_directories(include)
+
+# add the resized image message
+set(msg_files
+  "msg/ResizedImage.msg"
+)
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  DEPENDENCIES sensor_msgs
+)
+
+# add the publisher example
+add_executable(my_publisher src/my_publisher.cpp)
+ament_target_dependencies(my_publisher
+  "cv_bridge"
+  "image_transport"
+  "OpenCV"
+  "rclcpp")
+
+# add the subscriber example
+add_executable(my_subscriber src/my_subscriber.cpp)
+ament_target_dependencies(my_subscriber
+  "cv_bridge"
+  "image_transport"
+  "OpenCV"
+  "rclcpp")
+
+# add the plugin example
+add_library(resized_plugins src/manifest.cpp src/resized_publisher.cpp src/resized_subscriber.cpp)
+ament_target_dependencies(resized_plugins
+  "image_transport"
+  "OpenCV")
+
+# add the publisher from video example
+add_executable(publisher_from_video src/publisher_from_video.cpp)
+ament_target_dependencies(publisher_from_video
+  "cv_bridge"
+  "image_transport"
+  "OpenCV"
+  "rclcpp")
+
+# Install plugin descriptions
+pluginlib_export_plugin_description_file(${PROJECT_NAME} resized_plugins.xml)
+
+# Link interface
+rosidl_target_interfaces(resized_plugins
+  ${PROJECT_NAME} "rosidl_typesupport_cpp")
+
+# Install executables
+install(
+  TARGETS my_publisher my_subscriber resized_plugins publisher_from_video
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+# Install include directories
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+ament_export_include_directories(include)
+ament_export_dependencies(cv_bridge image_transport pluginlib rosidl_default_runtime rclcpp sensor_msgs)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/README.md
+++ b/README.md
@@ -1,0 +1,292 @@
+# image_transport_tutorial
+
+Before starting any of the tutorials below, create a workspace and clone the `image_common` repository so you can inspect and manipulate the code:
+
+```
+$ mkdir -p ~/image_transport_ws/src
+$ cd ~/image_transport_ws/src
+$ git clone --branch ros2 https://github.com/ros-perception/image_common.git
+```
+
+Install needed dependencies:
+
+```
+$ cd ~/image_transport_ws/
+$ source /opt/ros/galactic/setup.bash
+$ rosdep install -i --from-path src --rosdistro galactic -y
+$ colcon build
+```
+
+Make sure to include the correct setup file (in the above example it is for Galactic on Ubuntu and for bash).
+
+## Writing a Simple Image Publisher (C++)
+Description: This tutorial shows how to create a publisher node that will continually publish an image.
+
+Tutorial Level: Beginner
+
+Take a look at [my_publisher.cpp](src/my_publisher.cpp).
+
+### The code explained
+Now, let's break down the code piece by piece. 
+For lines not explained here, review [Writing a Simple Publisher and Subscriber (C++)](https://docs.ros.org/en/galactic/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.html).
+
+```
+#include <cv_bridge/cv_bridge.h>
+#include <image_transport/image_transport.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <rclcpp/rclcpp.hpp>
+```
+
+These headers will allow us to load an image using OpenCV, convert it to the ROS message format, and publish it.
+
+```
+rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("image_publisher", options);
+image_transport::ImageTransport it(node);
+```
+
+We create an `ImageTransport` instance, initializing it with our node. 
+We use methods of `ImageTransport` to create image publishers and subscribers, much as we use methods of `Node` to create generic ROS publishers and subscribers.
+
+```
+image_transport::Publisher pub = it.advertise("camera/image", 1);
+```
+
+Advertise that we are going to be publishing images on the base topic `camera/image`. 
+Depending on whether more plugins are built, additional (per-plugin) topics derived from the base topic may also be advertised. 
+The second argument is the size of our publishing queue.
+
+`advertise()` returns an `image_transport::Publisher` object, which serves two purposes:
+1. It contains a `publish()` method that lets you publish images onto the base topic it was created with
+2. When it goes out of scope, it will automatically unadvertise
+
+```
+cv::Mat image = cv::imread(argv[1], cv::IMREAD_COLOR);
+std_msgs::msg::Header hdr;
+sensor_msgs::msg::Image::SharedPtr msg;
+msg = cv_bridge::CvImage(hdr, "bgr8", image).toImageMsg();
+```
+
+We load a user-specified (on the command line) color image from disk using OpenCV, then convert it to the ROS type `sensor_msgs/msg/Image`.
+
+```
+rclcpp::WallRate loop_rate(5);
+while (rclcpp::ok()) {
+  pub.publish(msg);
+  rclcpp::spin_some(node);
+  loop_rate.sleep();
+}
+```
+
+We broadcast the image to anyone connected to one of our topics, exactly as we would have using an `rclcpp::Publisher`.
+
+### Adding video stream from a webcam
+The example above requires a path to an image file to be added as a command line parameter. 
+This image will be converted and sent as a message to an image subscriber. 
+In most cases, however, this is not a very practical example as you are often required to handle streaming data. 
+(For example: multiple webcams mounted on a robot record the scene around it and you have to pass the image data to some other node for further analysis). 
+
+The publisher example can be modified quite easily to make it work with a video device supported by `cv::VideoCapture` (in case it is not, you have to handle it accordingly). 
+Take a look at [publisher_from_video.cpp](src/publisher_from_video.cpp) to see how a video device can be passed in as a command line argument and used as the image source.
+
+If you have a single device, you do not need to do the whole routine with passing a command line argument. 
+In this case, you can hard-code the index/address of the device and directly pass it to the video capturing structure in OpenCV (example: `cv::VideoCapture(0)` if `/dev/video0` is used). 
+Multiple checks are also included here to make sure that the publisher does not break if the camera is shut down. 
+If the retrieved frame from the video device is not empty, it will then be converted to a ROS message which will be published by the publisher.
+
+## Writing a Simple Image Subscriber (C++)
+Description: This tutorial shows how to create a subscriber node that will display an image on the screen. 
+By using the `image_transport` subscriber to subscribe to images, any image transport can be used at runtime. 
+To learn how to actually use a specific image transport, see the next tutorial.
+
+Tutorial Level: Beginner
+
+Take a look at [my_subscriber.cpp](src/my_subscriber.cpp).
+
+### The code explained
+Now, let's break down the code piece by piece.
+
+```
+#include <cv_bridge/cv_bridge.h>
+#include <image_transport/image_transport.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include "rclcpp/logging.hpp"
+```
+
+These headers will allow us to subscribe to image messages, display images using OpenCV's simple GUI capabilities, and log errors.
+
+```
+void imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
+```
+
+This is the callback function that will be called when a new image has arrived on the `camera/image` topic. 
+Although the image may have been sent in some arbitrary transport-specific message type, notice that the callback need only handle the normal `sensor_msgs/msg/Image` type. 
+All image encoding/decoding is handled automatically for you.
+
+```
+try {
+  cv::imshow("view", cv_bridge::toCvShare(msg, "bgr8")->image);
+  cv::waitKey(10);
+} catch (cv_bridge::Exception & e) {
+  auto logger = rclcpp::get_logger("my_subscriber");
+  RCLCPP_ERROR(logger, "Could not convert from '%s' to 'bgr8'.", msg->encoding.c_str());
+```
+
+The body of the callback. 
+We convert the ROS image message into an OpenCV image with BGR pixel encoding, then show it in a display window.
+
+
+```
+rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("image_listener", options);
+image_transport::ImageTransport it(node);
+```
+
+We create an `ImageTransport` instance, initializing it with our node.
+
+```
+image_transport::Subscriber sub = it.subscribe("camera/image", 1, imageCallback);
+```
+
+Subscribe to the `camera/image` base topic. 
+The actual ROS topic subscribed to depends on which transport is used. 
+In the default case, "raw" transport, the topic is `camera/image` with type `sensor_msgs/msg/Image`. 
+ROS will call the `imageCallback` function whenever a new image arrives. 
+The 2nd argument is the queue size.
+
+`subscribe()` returns an `image_transport::Subscriber` object that you must hold on to until you want to unsubscribe. 
+When the Subscriber object is destructed, it will automatically unsubscribe from the `camera/image` base topic.
+
+In just a few lines of code, we have written a ROS image viewer that can handle images in both raw and a variety of compressed forms.
+
+## Running the Simple Image Publisher and Subscriber with Different Transports
+Description: This tutorial discusses running the simple image publisher and subscriber using multiple transports.
+
+Tutorial Level: Beginner
+
+### Running the publisher
+In a previous tutorial we made a publisher node called `my_publisher`. 
+Now run the node with an image file as the command-line argument:
+
+```
+$ ros2 run image_transport_tutorial my_publisher path/to/some/image.jpg
+```
+
+To check that your node is running properly, list the topics being published:
+
+```
+$ ros2 topic list
+```
+
+You should see `/camera/image` in the output. 
+You can also get more information about the topic:
+
+```
+$ ros2 topic info /camera/image
+```
+
+The output should be:
+
+```
+Type: sensor_msgs/msg/Image
+Publisher count: 1
+Subscription count: 0
+```
+
+### Running the subscriber
+In the last tutorial, we made a subscriber node called `my_subscriber`. Now run it:
+
+```
+$ ros2 run image_transport_tutorial my_subscriber
+```
+
+You should see a window pop up with the image you gave to the publisher.
+
+### Finding available transports
+`image_transport` searches your ROS installation for transport plugins at runtime and dynamically loads all that are built. 
+This affords you great flexibility in adding additional transports, but makes it unclear which are available on your system. 
+`image_transport` provides a `list_transports` executable for this purpose:
+
+```
+$ ros2 run image_transport list_transports
+```
+
+Which should show:
+
+```
+Declared transports:
+image_transport/raw
+
+Details:
+----------
+"image_transport/raw"
+ - Provided by package: image_transport
+ - Publisher: 
+      This is the default publisher. It publishes the Image as-is on the base topic.
+    
+ - Subscriber: 
+      This is the default pass-through subscriber for topics of type sensor_msgs/Image.
+```
+
+This the expected output for an otherwise new ROS installation after completing the previous tutorials. 
+Depending on your setup, you may already have "theora" or other transports available.
+
+### Adding new transports
+Our nodes are currently communicating raw `sensor_msgs/msg/Image` messages, so we are not gaining anything over using `rclcpp::Publisher` and `rclcpp::Subscriber`. 
+Let's change that by introducing a new transport.
+
+The `compressed_image_transport` package provides plugins for the "compressed" transport, which sends images over the wire in either JPEG- or PNG-compressed form. 
+Notice that `compressed_image_transport` is not a dependency of your package; `image_transport` will automatically discover all transport plugins built in your ROS system.
+
+The easiest way to add the "compressed" transport is to install the package:
+
+```
+$ sudo apt-get install ros-galactic-compressed-image-transport
+```
+
+Or install all the transport plugins at once:
+
+```
+$ sudo apt-get install ros-galactic-image-transport-plugins
+```
+
+But you can also build from source.
+
+### Changing the transport used
+Now let's start up a new subscriber, this one using compressed transport. 
+The key is that `image_transport` subscribers check the parameter `_image_transport` for the name of a transport to use in place of "raw". 
+Let's set this parameter and start a subscriber node with name "compressed_listener":
+
+```
+$ ros2 run image_transport_tutorial my_subscriber --ros-args --remap __name:=compressed_listener -p _image_transport:=compressed
+```
+
+You should see an identical image window pop up.
+
+`compressed_listener` is listening to a separate topic carrying JPEG-compressed versions of the same images published on `/camera/image`.
+
+### Changing transport-specific behavior
+For a particular transport, we may want to tweak settings such as compression level, bit rate, etc. 
+Transport plugins can expose such settings through ROS parameters. 
+For example, `/camera/image/compressed` allows you to change the compression format and quality on the fly; see the package documentation for full details.
+
+For now let's adjust the JPEG quality. 
+By default, the "compressed" transport uses JPEG compression at 80% quality. 
+Let's change it to 15%.
+We can use the GUI, `rqt_reconfigure`, to change the quality:
+
+```
+$ ros2 run rqt_reconfigure rqt_reconfigure
+```
+
+Now pick `/image_publisher` in the drop-down menu and move the `jpeg_quality` slider down to 15%. 
+Do you see the compression artifacts in your second view window?
+
+The `rqt_reconfigure` GUI has updated the ROS parameter `/image_publisher/jpeg_quality`. 
+You can verify this by running:
+
+```
+$ ros2 param get /image_publisher jpeg_quality
+```
+
+This should display 15.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# image_transport_tutorial
+# image_transport_tutorials
 
-Before starting any of the tutorials below, create a workspace and clone the `image_common` repository so you can inspect and manipulate the code:
+Before starting any of the tutorials below, create a workspace and clone this repository so you can inspect and manipulate the code:
 
 ```
-$ mkdir -p ~/image_transport_ws/src
-$ cd ~/image_transport_ws/src
-$ git clone --branch ros2 https://github.com/ros-perception/image_common.git
+$ mkdir -p ~/image_transport_tutorials_ws/src
+$ cd ~/image_transport_tutorials_ws/src
+$ git clone https://github.com/ros-perception/image_transport_tutorials.git
 ```
 
 Install needed dependencies:
 
 ```
-$ cd ~/image_transport_ws/
+$ cd ~/image_transport_tutorials_ws/
 $ source /opt/ros/galactic/setup.bash
 $ rosdep install -i --from-path src --rosdistro galactic -y
 $ colcon build
@@ -31,10 +31,10 @@ Now, let's break down the code piece by piece.
 For lines not explained here, review [Writing a Simple Publisher and Subscriber (C++)](https://docs.ros.org/en/galactic/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.html).
 
 ```
-#include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.hpp>
-#include <opencv2/highgui/highgui.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include "cv_bridge/cv_bridge.h"
+#include "image_transport/image_transport.hpp"
+#include "opencv2/highgui/highgui.hpp"
+#include "rclcpp/rclcpp.hpp"
 ```
 
 These headers will allow us to load an image using OpenCV, convert it to the ROS message format, and publish it.
@@ -106,12 +106,11 @@ Take a look at [my_subscriber.cpp](src/my_subscriber.cpp).
 Now, let's break down the code piece by piece.
 
 ```
-#include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.hpp>
-#include <opencv2/highgui/highgui.hpp>
-#include <rclcpp/rclcpp.hpp>
-
+#include "cv_bridge/cv_bridge.h"
+#include "image_transport/image_transport.hpp"
+#include "opencv2/highgui/highgui.hpp"
 #include "rclcpp/logging.hpp"
+#include "rclcpp/rclcpp.hpp"
 ```
 
 These headers will allow us to subscribe to image messages, display images using OpenCV's simple GUI capabilities, and log errors.
@@ -169,7 +168,7 @@ In a previous tutorial we made a publisher node called `my_publisher`.
 Now run the node with an image file as the command-line argument:
 
 ```
-$ ros2 run image_transport_tutorial my_publisher path/to/some/image.jpg
+$ ros2 run image_transport_tutorials my_publisher path/to/some/image.jpg
 ```
 
 To check that your node is running properly, list the topics being published:
@@ -197,7 +196,7 @@ Subscription count: 0
 In the last tutorial, we made a subscriber node called `my_subscriber`. Now run it:
 
 ```
-$ ros2 run image_transport_tutorial my_subscriber
+$ ros2 run image_transport_tutorials my_subscriber
 ```
 
 You should see a window pop up with the image you gave to the publisher.
@@ -258,7 +257,7 @@ The key is that `image_transport` subscribers check the parameter `_image_transp
 Let's set this parameter and start a subscriber node with name "compressed_listener":
 
 ```
-$ ros2 run image_transport_tutorial my_subscriber --ros-args --remap __name:=compressed_listener -p _image_transport:=compressed
+$ ros2 run image_transport_tutorials my_subscriber --ros-args --remap __name:=compressed_listener -p _image_transport:=compressed
 ```
 
 You should see an identical image window pop up.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ try {
 The body of the callback. 
 We convert the ROS image message into an OpenCV image with BGR pixel encoding, then show it in a display window.
 
-
 ```
 rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("image_listener", options);
 image_transport::ImageTransport it(node);

--- a/include/image_transport_tutorials/resized_publisher.hpp
+++ b/include/image_transport_tutorials/resized_publisher.hpp
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef IMAGE_TRANSPORT_TUTORIAL__RESIZED_PUBLISHER_HPP_
-#define IMAGE_TRANSPORT_TUTORIAL__RESIZED_PUBLISHER_HPP_
-
-#include <image_transport/simple_publisher_plugin.hpp>
-#include <image_transport_tutorial/msg/resized_image.hpp>
+#ifndef IMAGE_TRANSPORT_TUTORIALS__RESIZED_PUBLISHER_HPP_
+#define IMAGE_TRANSPORT_TUTORIALS__RESIZED_PUBLISHER_HPP_
 
 #include <string>
 
+#include "image_transport/simple_publisher_plugin.hpp"
+#include "image_transport_tutorials/msg/resized_image.hpp"
+
+
 class ResizedPublisher : public image_transport::SimplePublisherPlugin
-  <image_transport_tutorial::msg::ResizedImage>
+  <image_transport_tutorials::msg::ResizedImage>
 {
 public:
   virtual std::string getTransportName() const
@@ -35,4 +36,4 @@ protected:
     const PublishFn & publish_fn) const;
 };
 
-#endif  // IMAGE_TRANSPORT_TUTORIAL__RESIZED_PUBLISHER_HPP_
+#endif  // IMAGE_TRANSPORT_TUTORIALS__RESIZED_PUBLISHER_HPP_

--- a/include/image_transport_tutorials/resized_publisher.hpp
+++ b/include/image_transport_tutorials/resized_publisher.hpp
@@ -1,0 +1,38 @@
+// Copyright 2021, Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IMAGE_TRANSPORT_TUTORIAL__RESIZED_PUBLISHER_HPP_
+#define IMAGE_TRANSPORT_TUTORIAL__RESIZED_PUBLISHER_HPP_
+
+#include <image_transport/simple_publisher_plugin.hpp>
+#include <image_transport_tutorial/msg/resized_image.hpp>
+
+#include <string>
+
+class ResizedPublisher : public image_transport::SimplePublisherPlugin
+  <image_transport_tutorial::msg::ResizedImage>
+{
+public:
+  virtual std::string getTransportName() const
+  {
+    return "resized";
+  }
+
+protected:
+  virtual void publish(
+    const sensor_msgs::msg::Image & message,
+    const PublishFn & publish_fn) const;
+};
+
+#endif  // IMAGE_TRANSPORT_TUTORIAL__RESIZED_PUBLISHER_HPP_

--- a/include/image_transport_tutorials/resized_subscriber.hpp
+++ b/include/image_transport_tutorials/resized_subscriber.hpp
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef IMAGE_TRANSPORT_TUTORIAL__RESIZED_SUBSCRIBER_HPP_
-#define IMAGE_TRANSPORT_TUTORIAL__RESIZED_SUBSCRIBER_HPP_
-
-#include <image_transport/simple_subscriber_plugin.hpp>
-#include <image_transport_tutorial/msg/resized_image.hpp>
+#ifndef IMAGE_TRANSPORT_TUTORIALS__RESIZED_SUBSCRIBER_HPP_
+#define IMAGE_TRANSPORT_TUTORIALS__RESIZED_SUBSCRIBER_HPP_
 
 #include <string>
 
+#include "image_transport/simple_subscriber_plugin.hpp"
+#include "image_transport_tutorials/msg/resized_image.hpp"
+
 class ResizedSubscriber : public image_transport::SimpleSubscriberPlugin
-  <image_transport_tutorial::msg::ResizedImage>
+  <image_transport_tutorials::msg::ResizedImage>
 {
 public:
   virtual ~ResizedSubscriber() {}
@@ -32,19 +32,9 @@ public:
   }
 
 protected:
-  void subscribeImpl(
-    rclcpp::Node * node,
-    const std::string & base_topic,
-    const Callback & callback,
-    rmw_qos_profile_t custom_qos,
-    rclcpp::SubscriptionOptions options) override
-  {
-    this->subscribeImplWithOptions(node, base_topic, callback, custom_qos, options);
-  }
-
   virtual void internalCallback(
-    const typename image_transport_tutorial::msg::ResizedImage::ConstSharedPtr & message,
+    const typename image_transport_tutorials::msg::ResizedImage::ConstSharedPtr & message,
     const Callback & user_cb);
 };
 
-#endif  // IMAGE_TRANSPORT_TUTORIAL__RESIZED_SUBSCRIBER_HPP_
+#endif  // IMAGE_TRANSPORT_TUTORIALS__RESIZED_SUBSCRIBER_HPP_

--- a/include/image_transport_tutorials/resized_subscriber.hpp
+++ b/include/image_transport_tutorials/resized_subscriber.hpp
@@ -1,0 +1,50 @@
+// Copyright 2021, Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IMAGE_TRANSPORT_TUTORIAL__RESIZED_SUBSCRIBER_HPP_
+#define IMAGE_TRANSPORT_TUTORIAL__RESIZED_SUBSCRIBER_HPP_
+
+#include <image_transport/simple_subscriber_plugin.hpp>
+#include <image_transport_tutorial/msg/resized_image.hpp>
+
+#include <string>
+
+class ResizedSubscriber : public image_transport::SimpleSubscriberPlugin
+  <image_transport_tutorial::msg::ResizedImage>
+{
+public:
+  virtual ~ResizedSubscriber() {}
+
+  virtual std::string getTransportName() const
+  {
+    return "resized";
+  }
+
+protected:
+  void subscribeImpl(
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    const Callback & callback,
+    rmw_qos_profile_t custom_qos,
+    rclcpp::SubscriptionOptions options) override
+  {
+    this->subscribeImplWithOptions(node, base_topic, callback, custom_qos, options);
+  }
+
+  virtual void internalCallback(
+    const typename image_transport_tutorial::msg::ResizedImage::ConstSharedPtr & message,
+    const Callback & user_cb);
+};
+
+#endif  // IMAGE_TRANSPORT_TUTORIAL__RESIZED_SUBSCRIBER_HPP_

--- a/msg/ResizedImage.msg
+++ b/msg/ResizedImage.msg
@@ -1,0 +1,3 @@
+uint32 original_height
+uint32 original_width
+sensor_msgs/Image image

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,32 @@
+<package format="3">
+  <name>image_transport_tutorial</name>
+  <version>3.1.0</version>
+  <description>Tutorial for image_transport.</description>
+  <author>Vincent Rabaud</author>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <build_depend>cv_bridge</build_depend>
+  <build_depend>image_transport</build_depend>
+  <build_depend>libopencv-dev</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>cv_bridge</exec_depend>
+  <exec_depend>image_transport</exec_depend>
+  <exec_depend>libopencv-dev</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+    <image_transport plugin="${prefix}/resized_plugins.xml"/>
+  </export>
+</package>

--- a/package.xml
+++ b/package.xml
@@ -1,9 +1,9 @@
 <package format="3">
-  <name>image_transport_tutorial</name>
-  <version>3.1.0</version>
-  <description>Tutorial for image_transport.</description>
+  <name>image_transport_tutorials</name>
+  <version>0.0.0</version>
+  <description>Tutorials for image_transport.</description>
   <author>Vincent Rabaud</author>
-  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>

--- a/resized_plugins.xml
+++ b/resized_plugins.xml
@@ -1,0 +1,13 @@
+<library path="lib/libresized_image_transport">
+  <class name="resized_pub" type="ResizedPublisher" base_class_type="image_transport::PublisherPlugin">
+    <description>
+      This plugin publishes a decimated version of the image.
+    </description>
+  </class>
+
+  <class name="resized_sub" type="ResizedSubscriber" base_class_type="image_transport::SubscriberPlugin">
+    <description>
+      This plugin rescales a decimated image to its original size.
+    </description>
+  </class>
+</library>

--- a/src/manifest.cpp
+++ b/src/manifest.cpp
@@ -1,0 +1,21 @@
+// Copyright 2021, Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pluginlib/class_list_macros.hpp>
+
+#include "image_transport_tutorial/resized_publisher.hpp"
+#include "image_transport_tutorial/resized_subscriber.hpp"
+
+PLUGINLIB_EXPORT_CLASS(ResizedPublisher, image_transport::PublisherPlugin)
+PLUGINLIB_EXPORT_CLASS(ResizedSubscriber, image_transport::SubscriberPlugin)

--- a/src/manifest.cpp
+++ b/src/manifest.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <pluginlib/class_list_macros.hpp>
+#include "pluginlib/class_list_macros.hpp"
 
-#include "image_transport_tutorial/resized_publisher.hpp"
-#include "image_transport_tutorial/resized_subscriber.hpp"
+#include "image_transport_tutorials/resized_publisher.hpp"
+#include "image_transport_tutorials/resized_subscriber.hpp"
 
 PLUGINLIB_EXPORT_CLASS(ResizedPublisher, image_transport::PublisherPlugin)
 PLUGINLIB_EXPORT_CLASS(ResizedSubscriber, image_transport::SubscriberPlugin)

--- a/src/my_publisher.cpp
+++ b/src/my_publisher.cpp
@@ -1,0 +1,39 @@
+// Copyright 2021, Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cv_bridge/cv_bridge.h>
+#include <image_transport/image_transport.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::NodeOptions options;
+  rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("image_publisher", options);
+  image_transport::ImageTransport it(node);
+  image_transport::Publisher pub = it.advertise("camera/image", 1);
+
+  cv::Mat image = cv::imread(argv[1], cv::IMREAD_COLOR);
+  std_msgs::msg::Header hdr;
+  sensor_msgs::msg::Image::SharedPtr msg;
+  msg = cv_bridge::CvImage(hdr, "bgr8", image).toImageMsg();
+
+  rclcpp::WallRate loop_rate(5);
+  while (rclcpp::ok()) {
+    pub.publish(msg);
+    rclcpp::spin_some(node);
+    loop_rate.sleep();
+  }
+}

--- a/src/my_publisher.cpp
+++ b/src/my_publisher.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.hpp>
-#include <opencv2/highgui/highgui.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include "cv_bridge/cv_bridge.h"
+#include "image_transport/image_transport.hpp"
+#include "opencv2/highgui/highgui.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 int main(int argc, char ** argv)
 {

--- a/src/my_subscriber.cpp
+++ b/src/my_subscriber.cpp
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.hpp>
-#include <opencv2/highgui/highgui.hpp>
-#include <rclcpp/rclcpp.hpp>
-
+#include "cv_bridge/cv_bridge.h"
+#include "image_transport/image_transport.hpp"
+#include "opencv2/highgui/highgui.hpp"
 #include "rclcpp/logging.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 void imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
 {

--- a/src/my_subscriber.cpp
+++ b/src/my_subscriber.cpp
@@ -1,0 +1,44 @@
+// Copyright 2021, Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cv_bridge/cv_bridge.h>
+#include <image_transport/image_transport.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include "rclcpp/logging.hpp"
+
+void imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
+{
+  try {
+    cv::imshow("view", cv_bridge::toCvShare(msg, "bgr8")->image);
+    cv::waitKey(10);
+  } catch (cv_bridge::Exception & e) {
+    auto logger = rclcpp::get_logger("my_subscriber");
+    RCLCPP_ERROR(logger, "Could not convert from '%s' to 'bgr8'.", msg->encoding.c_str());
+  }
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::NodeOptions options;
+  rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("image_listener", options);
+  cv::namedWindow("view");
+  cv::startWindowThread();
+  image_transport::ImageTransport it(node);
+  image_transport::Subscriber sub = it.subscribe("camera/image", 1, imageCallback);
+  rclcpp::spin(node);
+  cv::destroyWindow("view");
+}

--- a/src/publisher_from_video.cpp
+++ b/src/publisher_from_video.cpp
@@ -1,0 +1,59 @@
+// Copyright 2021, Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cv_bridge/cv_bridge.h>
+#include <image_transport/image_transport.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <sstream>
+
+int main(int argc, char ** argv)
+{
+  // Check if video source has been passed as a parameter
+  if (argv[1] == NULL) {return 1;}
+
+  rclcpp::init(argc, argv);
+  rclcpp::NodeOptions options;
+  rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("image_publisher", options);
+  image_transport::ImageTransport it(node);
+  image_transport::Publisher pub = it.advertise("camera/image", 1);
+
+  // Convert the command line parameter index for the video device to an integer
+  std::istringstream video_sourceCmd(argv[1]);
+  int video_source;
+
+  // Check if it is indeed a number
+  if (!(video_sourceCmd >> video_source)) {return 1;}
+
+  cv::VideoCapture cap(video_source);
+  // Check if video device can be opened with the given index
+  if (!cap.isOpened()) {return 1;}
+  cv::Mat frame;
+  std_msgs::msg::Header hdr;
+  sensor_msgs::msg::Image::SharedPtr msg;
+
+  rclcpp::WallRate loop_rate(5);
+  while (rclcpp::ok()) {
+    cap >> frame;
+    // Check if grabbed frame is actually full with some content
+    if (!frame.empty()) {
+      msg = cv_bridge::CvImage(hdr, "bgr8", frame).toImageMsg();
+      pub.publish(msg);
+      cv::waitKey(1);
+    }
+
+    rclcpp::spin_some(node);
+    loop_rate.sleep();
+  }
+}

--- a/src/publisher_from_video.cpp
+++ b/src/publisher_from_video.cpp
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.hpp>
-#include <opencv2/highgui/highgui.hpp>
-#include <rclcpp/rclcpp.hpp>
 #include <sstream>
+
+#include "cv_bridge/cv_bridge.h"
+#include "image_transport/image_transport.hpp"
+#include "opencv2/highgui/highgui.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 int main(int argc, char ** argv)
 {

--- a/src/resized_publisher.cpp
+++ b/src/resized_publisher.cpp
@@ -1,0 +1,52 @@
+// Copyright 2021, Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/imgproc/imgproc.hpp>
+
+#include <memory>
+
+#include "image_transport_tutorial/resized_publisher.hpp"
+#include "rclcpp/logging.hpp"
+
+void ResizedPublisher::publish(
+  const sensor_msgs::msg::Image & message,
+  const PublishFn & publish_fn) const
+{
+  cv::Mat cv_image;
+  std::shared_ptr<void const> tracked_object;
+  try {
+    cv_image = cv_bridge::toCvShare(message, tracked_object, message.encoding)->image;
+  } catch (cv::Exception & e) {
+    auto logger = rclcpp::get_logger("resized_publisher");
+    RCLCPP_ERROR(
+      logger, "Could not convert from '%s' to '%s'.",
+      message.encoding.c_str(), message.encoding.c_str());
+    return;
+  }
+
+  // Rescale image
+  double subsampling_factor = 2.0;
+  int new_width = cv_image.cols / subsampling_factor + 0.5;
+  int new_height = cv_image.rows / subsampling_factor + 0.5;
+  cv::Mat buffer;
+  cv::resize(cv_image, buffer, cv::Size(new_width, new_height));
+
+  // Set up ResizedImage and publish
+  image_transport_tutorial::msg::ResizedImage resized_image;
+  resized_image.original_height = cv_image.rows;
+  resized_image.original_width = cv_image.cols;
+  resized_image.image = *(cv_bridge::CvImage(message.header, "bgr8", cv_image).toImageMsg());
+  publish_fn(resized_image);
+}

--- a/src/resized_publisher.cpp
+++ b/src/resized_publisher.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cv_bridge/cv_bridge.h>
-#include <opencv2/imgproc/imgproc.hpp>
+#include "image_transport_tutorials/resized_publisher.hpp"
 
 #include <memory>
 
-#include "image_transport_tutorial/resized_publisher.hpp"
+#include "cv_bridge/cv_bridge.h"
+#include "opencv2/imgproc/imgproc.hpp"
 #include "rclcpp/logging.hpp"
 
 void ResizedPublisher::publish(
@@ -44,7 +44,7 @@ void ResizedPublisher::publish(
   cv::resize(cv_image, buffer, cv::Size(new_width, new_height));
 
   // Set up ResizedImage and publish
-  image_transport_tutorial::msg::ResizedImage resized_image;
+  image_transport_tutorials::msg::ResizedImage resized_image;
   resized_image.original_height = cv_image.rows;
   resized_image.original_width = cv_image.cols;
   resized_image.image = *(cv_bridge::CvImage(message.header, "bgr8", cv_image).toImageMsg());

--- a/src/resized_subscriber.cpp
+++ b/src/resized_subscriber.cpp
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cv_bridge/cv_bridge.h>
-#include <opencv2/imgproc/imgproc.hpp>
+#include "image_transport_tutorials/resized_subscriber.hpp"
 
 #include <memory>
 
-#include "image_transport_tutorial/resized_subscriber.hpp"
+#include "cv_bridge/cv_bridge.h"
+#include "opencv2/imgproc/imgproc.hpp"
 
 void ResizedSubscriber::internalCallback(
-  const image_transport_tutorial::msg::ResizedImage::ConstSharedPtr & msg,
+  const image_transport_tutorials::msg::ResizedImage::ConstSharedPtr & msg,
   const Callback & user_cb)
 {
   // This is only for optimization, not to copy the image

--- a/src/resized_subscriber.cpp
+++ b/src/resized_subscriber.cpp
@@ -1,0 +1,36 @@
+// Copyright 2021, Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/imgproc/imgproc.hpp>
+
+#include <memory>
+
+#include "image_transport_tutorial/resized_subscriber.hpp"
+
+void ResizedSubscriber::internalCallback(
+  const image_transport_tutorial::msg::ResizedImage::ConstSharedPtr & msg,
+  const Callback & user_cb)
+{
+  // This is only for optimization, not to copy the image
+  std::shared_ptr<void const> tracked_object_tmp;
+  cv::Mat img_rsz = cv_bridge::toCvShare(msg->image, tracked_object_tmp)->image;
+  // Resize the image to its original size
+  cv::Mat img_restored;
+  cv::resize(img_rsz, img_restored, cv::Size(msg->original_width, msg->original_height));
+
+  // Call the user callback with the restored image
+  cv_bridge::CvImage cv_img(msg->image.header, msg->image.encoding, img_restored);
+  user_cb(cv_img.toImageMsg());
+}


### PR DESCRIPTION
I've moved the tutorials from ros-perception/image_common#197 to this repo so we can depend on `cv_bridge` without breaking CI.

@jacobperron has been added as the new maintainer.