### PR TITLE
Add a class callback based version of the my_subscriber tutorial

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,15 @@ ament_target_dependencies(my_subscriber
   "OpenCV"
   "rclcpp")
 
+# add the class subscriber example
+add_executable(my_class_subscriber src/my_class_subscriber.cpp)
+ament_target_dependencies(my_class_subscriber
+        "cv_bridge"
+        "image_transport"
+        "OpenCV"
+        "rclcpp")
+
+
 # add the plugin example
 add_library(resized_plugins src/manifest.cpp src/resized_publisher.cpp src/resized_subscriber.cpp)
 ament_target_dependencies(resized_plugins
@@ -69,7 +78,7 @@ rosidl_target_interfaces(resized_plugins
 
 # Install executables
 install(
-  TARGETS my_publisher my_subscriber resized_plugins publisher_from_video
+  TARGETS my_publisher my_subscriber my_class_subscriber resized_plugins publisher_from_video
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/src/my_class_subscriber.cpp
+++ b/src/my_class_subscriber.cpp
@@ -1,0 +1,53 @@
+#include "cv_bridge/cv_bridge.h"
+#include "image_transport/image_transport.hpp"
+#include "opencv2/highgui.hpp"
+#include "rclcpp/logging.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/image.hpp"
+
+/// Example Node ///
+
+class NodeThatNeedsImgs : public rclcpp::Node {
+public:
+  NodeThatNeedsImgs() : Node("node_that_needs_imgs"){};
+
+public:
+  void InitializeImageTransport() {
+    it_ = std::make_shared<image_transport::ImageTransport>(
+        this->shared_from_this()); // https://answers.ros.org/question/353828/getting-a-nodesharedptr-from-this/
+    it_img_sub_ = std::make_shared<image_transport::Subscriber>(
+        it_->subscribe("camera/image", 1,
+                       std::bind(&NodeThatNeedsImgs::ImgCallback, this,
+                                 std::placeholders::_1)));
+  }
+
+private:
+  void ImgCallback(sensor_msgs::msg::Image::ConstSharedPtr const &msg) {
+    try {
+      cv::imshow("view", cv_bridge::toCvShare(msg, "bgr8")->image);
+      cv::waitKey(10);
+    } catch (cv_bridge::Exception &e) {
+      auto logger = rclcpp::get_logger("my_subscriber");
+      RCLCPP_ERROR(logger, "Could not convert from '%s' to 'bgr8'.",
+                   msg->encoding.c_str());
+    }
+  }
+
+private:
+  std::shared_ptr<image_transport::ImageTransport> it_;
+  std::shared_ptr<image_transport::Subscriber> it_img_sub_;
+};
+
+/// Entry Point ///
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<NodeThatNeedsImgs>();
+  node->InitializeImageTransport();
+
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+
+  return 0;
+}


### PR DESCRIPTION
This PR expands on the my_subscriber.cpp tutorial by making it usable in a class. I am open to feedback on how we could make the code better, understandable, or more usable before merging. 

I understand that this type of application is in some ways already solved by the `image_transport::SimpleSubscriberPlugin` tutorial but I think it is not a bad idea to offer the user this additional tutorial as it bridges the gap in understanding between the  plugin tutorial and the `my_subscriber` tutorial.

It essentially answers this open issue: https://github.com/ros-perception/image_transport_tutorials/issues/3

Cheers!

Jack