### PR TITLE
Fixed cv bridge deprecated header warnings

### DIFF
--- a/src/my_publisher.cpp
+++ b/src/my_publisher.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cv_bridge/cv_bridge.h"
+#include "cv_bridge/cv_bridge.hpp"
 #include "image_transport/image_transport.hpp"
 #include "opencv2/core/mat.hpp"
 #include "opencv2/imgcodecs.hpp"

--- a/src/my_subscriber.cpp
+++ b/src/my_subscriber.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cv_bridge/cv_bridge.h"
+#include "cv_bridge/cv_bridge.hpp"
 #include "image_transport/image_transport.hpp"
 #include "opencv2/highgui.hpp"
 #include "rclcpp/logging.hpp"

--- a/src/publisher_from_video.cpp
+++ b/src/publisher_from_video.cpp
@@ -14,7 +14,7 @@
 
 #include <sstream>
 
-#include "cv_bridge/cv_bridge.h"
+#include "cv_bridge/cv_bridge.hpp"
 #include "image_transport/image_transport.hpp"
 #include "opencv2/core/mat.hpp"
 #include "opencv2/highgui.hpp"

--- a/src/resized_publisher.cpp
+++ b/src/resized_publisher.cpp
@@ -16,7 +16,7 @@
 
 #include <memory>
 
-#include "cv_bridge/cv_bridge.h"
+#include "cv_bridge/cv_bridge.hpp"
 #include "opencv2/core/mat.hpp"
 #include "opencv2/imgproc.hpp"
 #include "rclcpp/logging.hpp"

--- a/src/resized_subscriber.cpp
+++ b/src/resized_subscriber.cpp
@@ -16,7 +16,7 @@
 
 #include <memory>
 
-#include "cv_bridge/cv_bridge.h"
+#include "cv_bridge/cv_bridge.hpp"
 #include "opencv2/core/mat.hpp"
 #include "opencv2/imgproc.hpp"
 


### PR DESCRIPTION
This fixes the cv bridge header deprecation warnings. We're supposed to use the .hpp header instead of the .h one.